### PR TITLE
Fb computed lobby sizes

### DIFF
--- a/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
+++ b/LuaMenu/widgets/chobby/components/battle/battle_list_window.lua
@@ -691,9 +691,12 @@ function BattleListWindow:MakeJoinBattle(battleID, battle)
 		align = "right",
 		valign = 'center',
 		objectOverrideFont = myFont2,
-		caption = lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)),
+		caption = lobby:GetPlayerOccupancy(battleID),
 		parent = parentButton,
 	}
+
+	parentButton.previousMaxPlayers = lobby:GetBattleMaxPlayers(battleID)
+	parentButton.previousPlayerCount = lobby:GetBattlePlayerCount(battleID)
 
 	return parentButton
 end
@@ -1083,11 +1086,9 @@ function BattleListWindow:JoinedBattle(battleID)
 	local playersCaption = battleButton:GetChildByName("playersCaption")
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
-		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
+		if battleButton.previousPlayerCount ~= newPlayerCount then 
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
-			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 	else
 		local playersOnMapCaption = battleButton:GetChildByName("playersOnMapCaption")
@@ -1116,11 +1117,9 @@ function BattleListWindow:LeftBattle(battleID)
 	local playersCaption = battleButton:GetChildByName("playersCaption")
 	if playersCaption then
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
-		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
-			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
+		if battleButton.previousPlayerCount ~= newPlayerCount then 
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
-			battleButton.previousMaxPlayers = newMaxPlayers
 		end
 	else
 		local playersOnMapCaption = battleButton:GetChildByName("playersOnMapCaption")
@@ -1197,10 +1196,10 @@ function BattleListWindow:OnUpdateBattleInfo(battleID)
 		-- local gameCaption = items.battleButton:GetChildByName("gameCaption")
 		-- gameCaption:SetCaption(self:_MakeGameCaption(battle))
 		local newPlayerCount = lobby:GetBattlePlayerCount(battleID)
-		local newMaxPlayers = math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2))
+		local newMaxPlayers = lobby:GetBattleMaxPlayers(battleID)
 		if battleButton.previousPlayerCount ~= newPlayerCount or battleButton.previousMaxPlayers ~= newMaxPlayers then 
 			local playersCaption = battleButton:GetChildByName("playersCaption")
-			playersCaption:SetCaption(newPlayerCount .. "/" .. newMaxPlayers)
+			playersCaption:SetCaption(lobby:GetPlayerOccupancy(battleID))
 			battleButton.previousPlayerCount = newPlayerCount
 			battleButton.previousMaxPlayers = newMaxPlayers
 		end

--- a/LuaMenu/widgets/gui_battle_status_panel.lua
+++ b/LuaMenu/widgets/gui_battle_status_panel.lua
@@ -88,7 +88,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		height = 20,
 		valign = 'top',
 		objectOverrideFont = WG.Chobby.Configuration:GetFont(2),
-		caption = playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)),
+		caption = playersPrefix .. lobby:GetPlayerOccupancy(battleID),
 		parent = mainControl,
 	}
 
@@ -166,7 +166,7 @@ local function GetBattleInfoHolder(parent, battleID)
 		local text = StringUtilities.GetTruncatedStringWithDotDot(battle.title, lblTitle.font, smallMode and 150 or 180)
 		lblTitle:SetCaption(text)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 
 	function externalFunctions.Update(newBattleID)
@@ -197,7 +197,7 @@ local function GetBattleInfoHolder(parent, battleID)
 
 		externalFunctions.Resize(currentSmallMode)
 
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnUpdateBattleInfo", OnUpdateBattleInfo)
 
@@ -223,13 +223,13 @@ local function GetBattleInfoHolder(parent, battleID)
 		if updatedBattleID ~= battleID then
 			return
 		end
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnLeftBattle", PlayersUpdate)
 	lobby:AddListener("OnJoinedBattle", PlayersUpdate)
 
 	local function OnUpdateUserTeamStatus(listeners)
-		lblPlayers:SetCaption(playersPrefix .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		lblPlayers:SetCaption(playersPrefix .. lobby:GetPlayerOccupancy(battleID))
 	end
 	lobby:AddListener("OnUpdateUserTeamStatus", OnUpdateUserTeamStatus)
 

--- a/LuaMenu/widgets/gui_tooltip.lua
+++ b/LuaMenu/widgets/gui_tooltip.lua
@@ -341,7 +341,7 @@ local function GetBattleTooltip(battleID, battle, showMapName)
 		if not battleTooltip.playerCount then
 			battleTooltip.playerCount = GetTooltipLine(battleTooltip.mainControl)
 		end
-		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetBattlePlayerCount(battleID) .. "/" .. math.min(battle.maxPlayers, (battle.teamSize or 8) * (battle.nbTeams or 2)))
+		battleTooltip.playerCount.Update(offset, "Players: " .. lobby:GetPlayerOccupancy(battleID))
 
 		if not battleTooltip.spectatorCount then
 			battleTooltip.spectatorCount = GetTooltipLine(battleTooltip.mainControl, nil, nil, 130)

--- a/libs/liblobby/lobby/lobby.lua
+++ b/libs/liblobby/lobby/lobby.lua
@@ -2285,6 +2285,20 @@ function Lobby:GetBattlePlayerCount(battleID)
 	end
 end
 
+function Lobby:GetBattleMaxPlayers(battleID)
+	local battle = self:GetBattle(battleID)
+	if not battle then
+		return 0
+	end
+
+	-- fall back to maxPlayers, if nbTeams or teamSize is unknown
+	return (battle.teamSize and battle.nbTeams) and (battle.teamSize * battle.nbTeams) or battle.maxPlayers
+end
+
+function Lobby:GetPlayerOccupancy(battleID)
+	return self:GetBattlePlayerCount(battleID) .. "/" .. self:GetBattleMaxPlayers(battleID)
+end
+
 function Lobby:GetBattleFoundedBy(userName)
 	-- TODO, improve data structures to make this search nice
 	for battleID, battleData in pairs(self.battles) do


### PR DESCRIPTION
1. Refactor: extract repeated logic into function to avoid duplication for
GetBattleMaxPlayers and
GetPlayerOccupancy
2. Initialize battleButton.previousMaxPlayers and battleButton.previousMaxPlayers on button creation
and revert checking for previousMaxPlayers on JoinedBattle and LeftBattle, where no change to it occurs

